### PR TITLE
Improve frontmatter prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Replaced Ollama-based text generation with the `mlx.llm` API
 - Removed references to AUTOMATIC1111 and other non-Apple AI services
 - Updated README and requirements to reflect the simplified workflow
+- Generation prompt now explicitly requests a **Frontmatter** formatted post
 
 ### Fixed
 - Prevented crashes when newer and older versions of `mlx_lm` use

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Automatically generate, publish, and update SEO-optimized blog posts to WordPres
 **Trend Poster** continuously fetches trending headlines using NewsAPI and uses the `mlx.llm` model to generate:
 - Titles, meta descriptions, and keyphrases
 - Full blog posts written in Markdown and automatically converted to HTML (1000+ words)
+- Posts are returned in standard **Frontmatter** format for easy parsing
 - Featured image prompts (and auto-generated images)
 - SEO metadata integration (Yoast-compatible)
 - Seamless updates of existing posts (via slug detection)

--- a/post.py
+++ b/post.py
@@ -150,7 +150,7 @@ def generate_blog_components(topic):
         return cached
 
     prompt = f"""
-Write a witty markdown blog post about "{topic}". Begin with YAML front matter fenced by triple dashes containing: title, meta_title, meta_desc, slug, keyphrase, hero_image_prompt, inline_image_prompts, and alt_text. After the front matter, write the article in exactly three sections. Use a sarcastic tone throughout.
+Write a witty blog post about "{topic}" in Markdown. Format the output as a single file using YAML frontmatter: begin with `---`, include title, meta_title, meta_desc, slug, keyphrase, hero_image_prompt, inline_image_prompts, and alt_text, then close with `---`. After the frontmatter, write the article in exactly three sections using a sarcastic tone.
 """
 
     if load_model is None or generate_llm is None:


### PR DESCRIPTION
## Summary
- tweak the blog generation prompt to explicitly request a frontmatter formatted post
- document frontmatter return format in README
- note prompt change in CHANGELOG

## Testing
- `python -m unittest test_image_generation_unit.py test_ollama_utils.py` *(fails: ModuleNotFoundError)*