### PR TITLE
Fix YAML parsing failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Converted Markdown output to HTML before publishing to WordPress
 - Inserted inline images using the URL returned from the media upload endpoint
 - Truncated MLX image prompts to avoid token-length indexing errors on Apple NPU
+- Resolved YAML parsing failures when the LLM produces malformed front matter
 
 ## [Unreleased] - 2025-05-15
 


### PR DESCRIPTION
## Summary
- add `safe_frontmatter_loads` helper to fall back to sanitized parsing
- use the helper in `main`
- document the fix in the changelog

## Testing
- `python -m unittest test_image_generation_unit.py test_ollama_utils.py` *(fails: ModuleNotFoundError)*