### PR TITLE
Add refresh option to bypass caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## [Unreleased] - 2025-05-16
 
+### Added
+- `--refresh` option to bypass cached posts and images
+
 ### Changed
 - Replaced Ollama-based text generation with the `mlx.llm` API
 - Removed references to AUTOMATIC1111 and other non-Apple AI services

--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ Generate a blog post with your own topic:
 
 ```bash
 python post.py --idea "Amazing new tech" --keyphrase "latest tech trends"
+# Add --refresh to ignore caches
+python post.py --idea "Amazing new tech" --refresh
 ```
 
 ## Features
 
-- 🔁 Reuses cached posts and images for speed
+- 🔁 Reuses cached posts and images for speed (use `--refresh` to force regeneration)
 - 📤 Automatically publishes or updates matching slugs
 - 🧠 Logs to both `poster.log` and stdout (Kubernetes friendly)
 - 🌐 Fully async-compatible design

--- a/apple_utils.py
+++ b/apple_utils.py
@@ -71,6 +71,7 @@ def generate_image_with_mlx(
     steps: int = 30,
     guidance_scale: float = 9.0,
     seed: Optional[int] = None,
+    refresh: bool = False,
 ) -> Optional[str]:
     """
     Generate an image using MLX Core and CoreML on Apple Silicon.
@@ -99,16 +100,18 @@ def generate_image_with_mlx(
         if not base_prompt.lower().startswith("a "):
             base_prompt = "A " + base_prompt
         # Add tech-focused style modifiers
-        enhanced_prompt = base_prompt + ", ultra-realistic, high-tech, technological, photorealistic, detailed, sharp focus"
+        enhanced_prompt = (
+            base_prompt
+            + ", ultra-realistic, high-tech, technological, photorealistic, detailed, sharp focus"
+        )
         print(f"🎨 Final tech prompt for MLX Core: {enhanced_prompt}")
-        
-        
+
         # Create cache directory and check for cached image
         os.makedirs(".cache/images", exist_ok=True)
         cache_key = hashlib.sha256(enhanced_prompt.encode()).hexdigest()
         webp_path = f".cache/images/{cache_key}.webp"
 
-        if os.path.exists(webp_path):
+        if not refresh and os.path.exists(webp_path):
             print("🖼️ Cached WebP image used")
             return webp_path
 

--- a/post.py
+++ b/post.py
@@ -137,13 +137,18 @@ def clean_llm_output(text, topic=None):
     return text
 
 
-def generate_blog_components(topic):
-    """Generate an entire blog post in a single LLM call."""
+def generate_blog_components(topic, refresh: bool = False):
+    """Generate an entire blog post in a single LLM call.
+
+    Args:
+        topic (str): The topic for the post.
+        refresh (bool): If True, ignore cached content.
+    """
     os.makedirs(".cache/posts", exist_ok=True)
     cache_key = hashlib.sha256(topic.encode()).hexdigest()
     cache_path = f".cache/posts/{cache_key}.yaml"
 
-    if os.path.exists(cache_path):
+    if not refresh and os.path.exists(cache_path):
         with open(cache_path, "r") as f:
             cached = f.read()
         print(f"💾 Cached blog retrieved for: {topic}")
@@ -198,7 +203,13 @@ Return the entire output as a single Markdown file, and nothing else."""
 
 
 def generate_image(
-    prompt, negative_prompt="", width=512, height=512, steps=30, seed=None
+    prompt,
+    negative_prompt="",
+    width=512,
+    height=512,
+    steps=30,
+    seed=None,
+    refresh: bool = False,
 ):
     """
     Generate an image based on a text prompt.
@@ -216,12 +227,13 @@ def generate_image(
     # Check if the cache file exists
     png_path = f".cache/images/{cache_key}.png"
     webp_path = f".cache/images/{cache_key}.webp"
-    if os.path.exists(webp_path):
-        print("🖼️ Cached WebP image used")
-        return webp_path
-    elif os.path.exists(png_path):
-        print("🖼️ Cached PNG image used")
-        return png_path
+    if not refresh:
+        if os.path.exists(webp_path):
+            print("🖼️ Cached WebP image used")
+            return webp_path
+        elif os.path.exists(png_path):
+            print("🖼️ Cached PNG image used")
+            return png_path
 
     if is_apple_silicon():
         try:
@@ -233,6 +245,7 @@ def generate_image(
                 height=height,
                 steps=steps,
                 seed=seed,
+                refresh=refresh,
             )
             if image_path:
                 return image_path
@@ -378,6 +391,11 @@ def main():
     parser.add_argument(
         "--no-images", action="store_true", help="Skip image generation"
     )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Ignore caches and generate new content",
+    )
     args = parser.parse_args()
 
     if not args.idea:
@@ -386,7 +404,7 @@ def main():
 
     # Generate blog components
     print(f"🖋️ Generating blog post for topic: {args.idea}")
-    blog_content = generate_blog_components(args.idea)
+    blog_content = generate_blog_components(args.idea, refresh=args.refresh)
 
     # Extract YAML front matter
     try:
@@ -398,7 +416,7 @@ def main():
         if not args.no_images and "hero_image_prompt" in metadata:
             hero_prompt = metadata["hero_image_prompt"]
             print(f"🖼️ Generating hero image with prompt: {hero_prompt}")
-            image_path = generate_image(hero_prompt)
+            image_path = generate_image(hero_prompt, refresh=args.refresh)
             if image_path:
                 print(f"✅ Hero image generated: {image_path}")
             else:
@@ -414,7 +432,7 @@ def main():
             # Upload any inline images if needed
             if not args.no_images and "inline_image_prompts" in metadata:
                 for i, prompt in enumerate(metadata.get("inline_image_prompts", [])):
-                    image_path = generate_image(prompt)
+                    image_path = generate_image(prompt, refresh=args.refresh)
                     if image_path:
                         image_id, image_url = upload_image_to_wordpress(image_path)
                         if image_id and image_url:


### PR DESCRIPTION
## Summary
- add `--refresh` CLI flag to ignore cached posts and images
- allow bypassing caches in `generate_blog_components` and `generate_image`
- propagate refresh flag to MLX image generation
- document the new option in README and CHANGELOG

## Testing
- `python -m unittest test_image_generation_unit.py test_ollama_utils.py` *(fails: ModuleNotFoundError)*