### PR TITLE
Fix frontmatter stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Inserted inline images using the URL returned from the media upload endpoint
 - Truncated MLX image prompts to avoid token-length indexing errors on Apple NPU
 - Resolved YAML parsing failures when the LLM produces malformed front matter
+- Improved frontmatter stripping to handle missing closing `---` markers
 
 ## [Unreleased] - 2025-05-15
 

--- a/post.py
+++ b/post.py
@@ -44,10 +44,8 @@ LLM_MODEL = os.getenv("MLX_LLM_MODEL", "mistralai/Mistral-7B-Instruct-v0.2")
 
 
 def _strip_frontmatter(text):
-    """
-    Strip YAML front matter from text.
-    """
-    pattern = r"^\s*---\s*\n.*?\n---\s*\n"
+    """Strip YAML front matter from text even if the closing marker is missing."""
+    pattern = r"^\s*---\s*\n.*?(?:\n---\s*\n|$)"
     return re.sub(pattern, "", text, flags=re.DOTALL)
 
 


### PR DESCRIPTION
## Summary
- handle missing closing frontmatter markers when stripping YAML
- document the fix in CHANGELOG

## Testing
- `python -m unittest test_image_generation_unit.py test_ollama_utils.py` *(fails: ModuleNotFoundError)*